### PR TITLE
Fix: Migrate authentication to updated GO DAIKIN API

### DIFF
--- a/custom_components/godaikin/api.py
+++ b/custom_components/godaikin/api.py
@@ -10,7 +10,7 @@ import logging
 from .auth import AuthClient
 from .types import *
 
-BASE_URL = "https://c7zkf7l933.execute-api.ap-southeast-1.amazonaws.com/prod/"
+BASE_URL = "https://jm41kogy2b.execute-api.ap-southeast-1.amazonaws.com/prod/"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,12 +35,13 @@ class ApiClient:
     async def get_airconds(self) -> list[Aircond]:
         _LOGGER.debug("Getting airconds")
 
+        user_id = await self.auth.async_get_user_id()
         response_data = await self._api_request(
-            "gethomepageinfowithsubscription",
+            "gethomepage",
             {
                 "requestData": {
                     "type": 1,
-                    "value": self.auth.username,
+                    "userID": user_id,
                 }
             },
         )

--- a/custom_components/godaikin/auth.py
+++ b/custom_components/godaikin/auth.py
@@ -1,20 +1,20 @@
 """
-Authenticates against AWS Cognito to obtain JWT tokens for GO DAIKIN API access.
+Authenticates against GO DAIKIN universallogin endpoint to obtain JWT tokens.
 """
 
 from __future__ import annotations
 
 import asyncio
-import boto3
+import base64
 from dataclasses import dataclass
 from datetime import datetime as dt, timedelta
+import json
 import logging
 
-REGION = "ap-southeast-1"
-CLIENT_ID = "36f6piu770fotfscvhi3jb1vb7"
-EXPIRY_BUFFER = timedelta(
-    minutes=5
-)  # refresh this much before expiry, in case of clock drift
+import aiohttp
+
+LOGIN_URL = "https://qr5sjbuvhd.execute-api.ap-southeast-1.amazonaws.com/prod/universallogin"
+EXPIRY_BUFFER = timedelta(minutes=5)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,86 +24,56 @@ class AuthClient:
         self.username = username
         self.password = password
 
-        self.get_jwt_token_semaphore = asyncio.Semaphore(1)
-        self.session = boto3.Session()
-        self.token: CognitoToken | None = None
+        self._lock = asyncio.Lock()
+        self._token: CognitoToken | None = None
 
     async def async_get_jwt_token(self) -> str:
-        # Semaphore to prevent stampede on token init/refresh
-        async with self.get_jwt_token_semaphore:
-            return await asyncio.to_thread(self.get_jwt_token)
+        async with self._lock:
+            if not self._token or self._token.expires_at <= dt.now() + EXPIRY_BUFFER:
+                _LOGGER.debug("Fetching new token from universallogin")
+                self._token = await self._login()
+            return self._token.access_token
 
-    def get_jwt_token(self) -> str:
-        if not self.token:
-            _LOGGER.debug("Initializing cognito token")
-            self.token = self.init_cognito_token()
+    async def async_get_user_id(self) -> str:
+        await self.async_get_jwt_token()
+        return self._token.user_id
 
-        if self.token.expires_at <= dt.now() + EXPIRY_BUFFER:
-            _LOGGER.debug("Refreshing cognito token")
-            self.token = self.refresh_jwt_token(self.token)
+    async def _login(self) -> CognitoToken:
+        session = aiohttp.ClientSession()
+        try:
+            async with session.post(
+                LOGIN_URL,
+                json={"requestData": {"username": self.username, "password": self.password}},
+            ) as resp:
+                if resp.status == 401:
+                    raise AuthError("Invalid credentials")
+                resp.raise_for_status()
+                data = await resp.json()
+        finally:
+            await session.close()
 
-        return self.token.id_token
+        if "IdToken" not in data:
+            raise AuthError(f"Unexpected login response: {data}")
 
-    def init_cognito_token(self) -> CognitoToken:
-        cognito = self.session.client("cognito-idp", region_name=REGION)
-        resp = cognito.initiate_auth(
-            ClientId=CLIENT_ID,
-            AuthFlow="USER_PASSWORD_AUTH",
-            AuthParameters={
-                "USERNAME": self.username,
-                "PASSWORD": self.password,
-            },
-        )
-
-        auth = resp.get("AuthenticationResult")
-        if not auth:
-            _LOGGER.error("Authentication failed - no AuthenticationResult received")
-            raise AuthError(
-                "Did not receive AuthenticationResult (auth failed or unhandled challenge)."
-            )
+        id_token = data["IdToken"]
+        user_id = _decode_jwt_sub(id_token)
 
         token = CognitoToken(
-            access_token=auth["AccessToken"],
-            id_token=auth["IdToken"],
-            refresh_token=auth["RefreshToken"],
-            expires_at=dt.now() + timedelta(seconds=auth["ExpiresIn"]),
+            id_token=id_token,
+            access_token=data.get("AccessToken", ""),
+            refresh_token=data.get("RefreshToken", ""),
+            expires_at=dt.now() + timedelta(seconds=data.get("ExpiresIn", 3600)),
+            user_id=user_id,
         )
-        _LOGGER.debug(
-            "Cognito authentication successful, expires at %s",
-            token.expires_at.isoformat(),
-        )
-
+        _LOGGER.debug("Login successful, token expires at %s", token.expires_at.isoformat())
         return token
 
-    def refresh_jwt_token(self, token: CognitoToken) -> CognitoToken:
-        cognito = self.session.client("cognito-idp", region_name=REGION)
-        resp = cognito.initiate_auth(
-            ClientId=CLIENT_ID,
-            AuthFlow="REFRESH_TOKEN_AUTH",
-            AuthParameters={
-                "REFRESH_TOKEN": token.refresh_token,
-            },
-        )
 
-        auth = resp.get("AuthenticationResult")
-        if not auth:
-            _LOGGER.error("Token refresh failed - no AuthenticationResult received")
-            raise AuthError(
-                "Did not receive AuthenticationResult (refresh failed or unhandled challenge)."
-            )
-
-        token = CognitoToken(
-            access_token=auth["AccessToken"],
-            id_token=auth["IdToken"],
-            refresh_token=token.refresh_token,  # reuse the prior refresh token
-            expires_at=dt.now() + timedelta(seconds=auth["ExpiresIn"]),
-        )
-        _LOGGER.debug(
-            "Cognito token refresh successful, expires at %s",
-            token.expires_at.isoformat(),
-        )
-
-        return token
+def _decode_jwt_sub(token: str) -> str:
+    payload = token.split(".")[1]
+    payload += "=" * (4 - len(payload) % 4)
+    data = json.loads(base64.b64decode(payload))
+    return data["sub"]
 
 
 class AuthError(Exception):
@@ -112,7 +82,8 @@ class AuthError(Exception):
 
 @dataclass
 class CognitoToken:
-    access_token: str
     id_token: str
+    access_token: str
     refresh_token: str
     expires_at: dt
+    user_id: str = ""

--- a/custom_components/godaikin/config_flow.py
+++ b/custom_components/godaikin/config_flow.py
@@ -43,9 +43,6 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
         api = ApiClient(auth)
         airconds = await api.get_airconds()
 
-        if not airconds:
-            raise NoAirConditionersFound()
-
     except AuthError as err:
         raise InvalidAuth() from err
     except Exception as err:


### PR DESCRIPTION
The integration stopped working due to breaking changes in the GO DAIKIN backend API. The previous implementation used `boto3` to authenticate directly against AWS Cognito, and called a deprecated API Gateway endpoint — both of which are no longer functional.

## Root Cause

GO DAIKIN has updated their infrastructure:
- Authentication now goes through a custom `universallogin` endpoint instead of direct Cognito `InitiateAuth`
- The API base URL has changed to a new API Gateway instance
- The homepage endpoint was renamed from `gethomepageinfowithsubscription` to `gethomepage`
- API calls now require `AccessToken` (not `IdToken`) and `userID` (UUID from JWT `sub` claim, not email)

## Changes

### `auth.py`
- Remove `boto3` dependency entirely — no longer needed
- Authenticate via `POST /universallogin` using `aiohttp` (already a project dependency)
- Extract `userID` (UUID) from JWT `sub` claim to be used in API requests
- Token refresh handled natively via re-login before expiry

### `api.py`
- Update `BASE_URL` to new API Gateway endpoint
- Rename `gethomepageinfowithsubscription` → `gethomepage`
- Replace `"value": username` with `"userID": uuid` in request payload
- Use `AccessToken` instead of `IdToken` for authorization header

### `config_flow.py`
- Remove `NoAirConditionersFound` guard — integration can now be set up before any AC units are registered in the GO DAIKIN app

## Testing

Verified on Home Assistant running in Docker with a live GO DAIKIN account. Authentication succeeds and the integration loads correctly.